### PR TITLE
Give the ability to optionally pass timeout value to rabbit-chatter.

### DIFF
--- a/lib/winston-fast-rabbitmq.js
+++ b/lib/winston-fast-rabbitmq.js
@@ -56,7 +56,8 @@ class WinstonFastRabbitMq {
             virtualHost: options.virtualHost ? options.virtualHost : '',
             port: options.port || 5672,
             routingKey: options.routingKey || '',
-            handleError: options.handleError
+            timeout: options.timeout || 1000,
+            handleError: options.handleError,
         };
 
         this._rabbit = rabbitChatter.rabbit(rabbitOptions);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "amqplib": "^0.5.1",
-    "rabbit-chatter": "^1.1.6",
+    "rabbit-chatter": "^1.2.0",
     "util": "^0.10.3",
     "winston": "^2.3.1"
   },

--- a/typings/winston-fast-rabbitmq.d.ts
+++ b/typings/winston-fast-rabbitmq.d.ts
@@ -22,6 +22,7 @@ declare module 'winston' {
         port?: number;
         protocol?: string;
         routingKey?: string;
+        timeout?: number;
         username?: string;
         virtualHost?: string;
         handleError?(err: any): void;


### PR DESCRIPTION
This PR should be merged if https://github.com/TBear79/rabbit-chatter/pull/6 is accepted and `rabbit-chatter` `1.2.0` gets released.

This PR justifies a version bump to `2.1.0`.